### PR TITLE
Change port for mac compatibility; Use Antala build

### DIFF
--- a/examples/docker-compose/.ice.yaml
+++ b/examples/docker-compose/.ice.yaml
@@ -1,4 +1,4 @@
-uri: http://localhost:5000
+uri: http://localhost:5001
 bearerToken: foo
 s3:
   endpoint: http://localhost:8999

--- a/examples/docker-compose/docker-compose.yaml
+++ b/examples/docker-compose/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
     pull_policy: ${ICE_REST_CATALOG_PULL_POLICY:-always}
     restart: unless-stopped
     ports:
-      - '5000:5000' # iceberg/http
+      - '5001:5000' # iceberg/http
     configs:
       - source: ice-rest-catalog-yaml
         target: /etc/ice/ice-rest-catalog.yaml
@@ -40,7 +40,7 @@ services:
     depends_on:
       - minio-init
   clickhouse:
-    image: clickhouse/clickhouse-server:latest
+    image: altinity/clickhouse-server:25.3.3.20186.altinityantalya-alpine
     restart: unless-stopped
     environment:
       CLICKHOUSE_SKIP_USER_SETUP: "1" # insecure


### PR DESCRIPTION
- Apple Airplay uses port 5000.
- `allow_experimental_database_iceberg` setting does not exist in `clickhouse/clickhouse-server:latest`
