### PR TITLE
Fixing corrupted metadata issue (#57)

### DIFF
--- a/ice-rest-catalog/src/main/java/com/altinity/ice/rest/catalog/internal/rest/RESTCatalogServlet.java
+++ b/ice-rest-catalog/src/main/java/com/altinity/ice/rest/catalog/internal/rest/RESTCatalogServlet.java
@@ -27,7 +27,18 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpHeaders;
-import org.apache.iceberg.exceptions.*;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.exceptions.CommitStateUnknownException;
+import org.apache.iceberg.exceptions.ForbiddenException;
+import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
+import org.apache.iceberg.exceptions.NoSuchIcebergTableException;
+import org.apache.iceberg.exceptions.NoSuchNamespaceException;
+import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.exceptions.NoSuchViewException;
+import org.apache.iceberg.exceptions.NotAuthorizedException;
+import org.apache.iceberg.exceptions.UnprocessableEntityException;
+import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.io.CharStreams;
 import org.apache.iceberg.rest.HTTPRequest;
@@ -53,7 +64,6 @@ public class RESTCatalogServlet extends HttpServlet {
           .put(NoSuchTableException.class, 404)
           .put(NoSuchViewException.class, 404)
           .put(NoSuchIcebergTableException.class, 404)
-          .put(NotFoundException.class, 404)
           .put(UnsupportedOperationException.class, 406)
           .put(AlreadyExistsException.class, 409)
           .put(CommitFailedException.class, 409)

--- a/ice/src/main/java/com/altinity/ice/cli/internal/cmd/Describe.java
+++ b/ice/src/main/java/com/altinity/ice/cli/internal/cmd/Describe.java
@@ -23,9 +23,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
-import org.apache.iceberg.*;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.TableScan;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.ServiceFailureException;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.rest.RESTCatalog;
 import org.apache.iceberg.types.Conversions;
@@ -77,8 +81,7 @@ public final class Describe {
         try {
           tableData = gatherTableData(catalog, tableId, optionsSet);
           tableMetadata = new Table.Metadata(tableId.toString());
-        } catch (Exception e) {
-          e.printStackTrace(System.err);
+        } catch (ServiceFailureException e) {
           tableMetadata = new Table.Metadata(tableId.toString(), e.getMessage());
         }
 


### PR DESCRIPTION
### Problem

Due to incorrect error propagation (returning 500 instead of 404) for Iceberg `NotFoundException`, REST clients keep retrying the same requests, causing them to appear to hang (e.g., ClickHouse `SHOW TABLES` or `ice delete-table`).

Additionally, the `ice describe` command fails when one of the tables has corrupted metadata.

### Solution

1. Return the correct 404 status code for `NotFoundException`.
2. Fix the `ice describe` handler to include corrupted tables in the result set, using the newly introduced `status` field.

Fixes: [https://github.com/Altinity/ice/issues/57](https://github.com/Altinity/ice/issues/57)

### Example
<img width="1108" height="242" alt="Screenshot 2025-11-07 at 16 40 22" src="https://github.com/user-attachments/assets/cecde355-3999-4a40-ab5f-6bcb43ba7003" />

