### PR TITLE
fix: Allow dropping of empty namespaces

### DIFF
--- a/ice-rest-catalog/pom.xml
+++ b/ice-rest-catalog/pom.xml
@@ -393,7 +393,6 @@
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
       <version>${jackson.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.etcd</groupId>

--- a/ice-rest-catalog/src/main/java/com/altinity/ice/rest/catalog/internal/etcd/EtcdCatalog.java
+++ b/ice-rest-catalog/src/main/java/com/altinity/ice/rest/catalog/internal/etcd/EtcdCatalog.java
@@ -203,7 +203,6 @@ public class EtcdCatalog extends BaseMetastoreCatalog implements SupportsNamespa
 
   @Override
   public List<Namespace> listNamespaces(Namespace namespace) throws NoSuchNamespaceException {
-    validateNamespace(namespace);
     String prefix = namespaceKey(namespace);
     prefix = prefix.endsWith("/") ? prefix : prefix + "/";
     GetResponse res = unwrap(kv.get(byteSeq(prefix), GetOption.builder().isPrefix(true).build()));
@@ -241,11 +240,11 @@ public class EtcdCatalog extends BaseMetastoreCatalog implements SupportsNamespa
 
   @Override
   public boolean dropNamespace(Namespace namespace) throws NamespaceNotEmptyException {
-    validateNamespace(namespace);
     if (!namespaceExists(namespace)) {
       throw new NoSuchNamespaceException("Namespace does not exist: %s", namespace);
     }
-    if (!listNamespaces(namespace).isEmpty() || !listTables(namespace).isEmpty()) {
+    if (!namespace.level(0).isEmpty()
+        && (!listNamespaces(namespace).isEmpty() || !listTables(namespace).isEmpty())) {
       throw new NamespaceNotEmptyException("Cannot drop non-empty namespace: " + namespace);
     }
     // FIXME: child ns/table might have been created since check ^
@@ -336,7 +335,6 @@ public class EtcdCatalog extends BaseMetastoreCatalog implements SupportsNamespa
 
   @Override
   public List<TableIdentifier> listTables(Namespace namespace) {
-    validateNamespace(namespace);
     String prefix = tableKey(namespace);
     prefix = prefix.endsWith("/") ? prefix : prefix + "/";
     GetResponse res = unwrap(kv.get(byteSeq(prefix), GetOption.builder().isPrefix(true).build()));


### PR DESCRIPTION
Changes ice-rest-catalog to allow empty namespaces to be dropped from etcd catalog. Requires using REST endpoint, not ice:
```
curl -X DELETE -H "Authorization: Bearer foo" localhost:5000/v1/namespaces/""
```
Considering this deviates from the "correct" behavior, we would likely need to revert this later and ensure permanent fixes that prevent any empty namespaces from being created.