### PR TITLE
chore: Add git-cliff config for generating release notes

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,45 @@
+[changelog]
+body = """
+{%- macro remote_url() -%}
+  https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}
+{%- endmacro -%}
+
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}]({{ self::remote_url() }}/compare/{{ previous.version }}...{{ version }})
+{% else %}\
+    ## [Unreleased]({{ self::remote_url() }}/compare/{{ previous.version }}...master)
+{% endif %}\
+
+{% for group, commits in commits | unique(attribute="message") | group_by(attribute="group") %}
+    ### {{ group | upper_first }}
+    {% for commit in commits %}
+        {%- set display_scope = commit.scope %}
+        {%- if commit.remote.pr_labels is containing("ice-rest-catalog") %}
+            {%- set display_scope = "ice-rest-catalog" %}
+        {%- elif commit.remote.pr_labels is containing("ice") %}
+            {%- set display_scope = "ice" %}
+        {%- endif %}
+        - {% if display_scope %}`{{ display_scope }}` - {% endif %}{{ commit.message | upper_first }}\
+    {% endfor %}
+{% endfor %}
+"""
+
+[git]
+filter_unconventional = false
+commit_parsers = [
+  { message = "^feat", group = "Added" },
+  { message = "^change", group = "Changed" },
+  { message = "^fix", group = "Fixed" },
+  { message = "^Merge pull request #.*", skip = true},
+  { message = "^docs", skip = true },
+  { message = "^test", skip = true },
+  { message = "^chore", skip = true },
+  { message = ".*", group = "Other" },
+]
+commit_preprocessors = [
+  { pattern = "\\(#([0-9]+)\\)", replace = "([#${1}](https://github.com/Altinity/ice/pull/${1}))" },
+]
+
+[remote.github]
+owner = "Altinity"
+repo = "ice"


### PR DESCRIPTION
Closes #134.

Use by installing git-cliff, then running `git-cliff -u -c cliff.toml` for unreleased commits. For changelog between two release tags, use `git-cliff v0.12.0..v0.13.0 -c cliff.toml`. All future commits should use the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) format to be properly parsed. `docs:`, `test:`, and `chore:` commits are excluded from the changelog.