### PR TITLE
test: Add property to filter specific scenario tests to run

### DIFF
--- a/ice-rest-catalog/src/test/java/com/altinity/ice/rest/catalog/RESTCatalogTestBase.java
+++ b/ice-rest-catalog/src/test/java/com/altinity/ice/rest/catalog/RESTCatalogTestBase.java
@@ -20,6 +20,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.catalog.Catalog;
@@ -218,6 +219,17 @@ public abstract class RESTCatalogTestBase {
     Path scenariosDir = getScenariosDirectory();
     ScenarioTestRunner runner = new ScenarioTestRunner(scenariosDir, Map.of());
     List<String> scenarios = runner.discoverScenarios();
+
+    String filtered = System.getProperty("scenario");
+    if (filtered != null && !filtered.isBlank()) {
+      List<String> requested =
+          Arrays.stream(filtered.split(",")).map(String::trim).filter(s -> !s.isEmpty()).toList();
+      scenarios = scenarios.stream().filter(requested::contains).toList();
+      if (scenarios.isEmpty()) {
+        throw new IllegalArgumentException(
+            "No scenarios matched -Dscenario=" + filtered + " in " + scenariosDir);
+      }
+    }
 
     if (scenarios.isEmpty()) {
       logger.warn("No test scenarios found in: {}", scenariosDir);

--- a/ice-rest-catalog/src/test/resources/scenarios/README.md
+++ b/ice-rest-catalog/src/test/resources/scenarios/README.md
@@ -98,11 +98,9 @@ Scenarios are discovered and executed automatically by the `ScenarioBasedIT` tes
 mvn test -Dtest=ScenarioBasedIT
 ```
 
-To run a specific scenario:
+To run a specific scenario, pass `-Dscenario=<name>` (comma-separated for multiple):
 
 ```bash
-mvn test -Dtest=ScenarioBasedIT#testScenario[basic-operations]
+mvn test -Dtest=ScenarioBasedIT -Dscenario=basic-operations
+mvn test -Dtest=ScenarioBasedIT -Dscenario=basic-operations,describe-parquet
 ```
-
-
-


### PR DESCRIPTION
Closes #160. The currently listed syntax for running an individual scenario does not work. This fixes it by adding a system property to filter specific scenarios to run using:
```
mvn test -Dtest=ScenarioBasedIT -Dscenario=basic-operations
mvn test -Dtest=ScenarioBasedIT -Dscenario=basic-operations,describe-parquet
```