### PR TITLE
feat: Add logs to display catalog backend (etcd/sqlite) and timeout for etcd

### DIFF
--- a/ice-rest-catalog/src/main/java/com/altinity/ice/rest/catalog/Main.java
+++ b/ice-rest-catalog/src/main/java/com/altinity/ice/rest/catalog/Main.java
@@ -539,8 +539,7 @@ public final class Main implements Callable<Integer> {
       catalog = CatalogUtil.buildIcebergCatalog(catalogName, icebergConfig, null);
       String uri = icebergConfig.getOrDefault(CatalogProperties.URI, "");
       if (uri.toLowerCase().startsWith("jdbc:sqlite:")) {
-        logger.warn(
-            "Catalog backend: SQLite ({}); not recommended for production use", uri);
+        logger.warn("Catalog backend: SQLite ({}); not recommended for production use", uri);
       } else {
         logger.info("Catalog backend: {} ({})", catalogImpl, uri);
       }

--- a/ice-rest-catalog/src/main/java/com/altinity/ice/rest/catalog/Main.java
+++ b/ice-rest-catalog/src/main/java/com/altinity/ice/rest/catalog/Main.java
@@ -534,8 +534,16 @@ public final class Main implements Callable<Integer> {
     Catalog catalog;
     if (EtcdCatalog.class.getName().equals(catalogImpl)) {
       catalog = newEctdCatalog(catalogName, icebergConfig);
+      logger.info("Catalog backend: etcd");
     } else {
       catalog = CatalogUtil.buildIcebergCatalog(catalogName, icebergConfig, null);
+      String uri = icebergConfig.getOrDefault(CatalogProperties.URI, "");
+      if (uri.toLowerCase().startsWith("jdbc:sqlite:")) {
+        logger.warn(
+            "Catalog backend: SQLite ({}); not recommended for production use", uri);
+      } else {
+        logger.info("Catalog backend: {} ({})", catalogImpl, uri);
+      }
     }
     return catalog;
   }

--- a/ice-rest-catalog/src/main/java/com/altinity/ice/rest/catalog/internal/etcd/EtcdCatalog.java
+++ b/ice-rest-catalog/src/main/java/com/altinity/ice/rest/catalog/internal/etcd/EtcdCatalog.java
@@ -34,6 +34,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.apache.iceberg.BaseMetastoreCatalog;
 import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.CatalogUtil;
@@ -61,6 +63,8 @@ public class EtcdCatalog extends BaseMetastoreCatalog implements SupportsNamespa
 
   private static final Logger logger = LoggerFactory.getLogger(EtcdCatalog.class);
 
+  private static final long DEFAULT_TIMEOUT_SECONDS = 30;
+
   private static final String NAMESPACE_PREFIX = "n/";
   private static final String TABLE_PREFIX = "t/";
 
@@ -79,6 +83,29 @@ public class EtcdCatalog extends BaseMetastoreCatalog implements SupportsNamespa
         Client.builder().endpoints(uri.split(",")).keepaliveWithoutCalls(false).build();
     this.client = etcdClient;
     this.kv = etcdClient.getKVClient();
+    try {
+      kv.get(ByteSequence.from("/", StandardCharsets.UTF_8))
+          .get(DEFAULT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+      logger.info("Connected to etcd at {}", uri);
+    } catch (TimeoutException e) {
+      throw new RuntimeIOException(
+          new IOException(
+              "Failed to connect to etcd at "
+                  + uri
+                  + ": timed out after "
+                  + DEFAULT_TIMEOUT_SECONDS
+                  + "s",
+              e));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeIOException(
+          new IOException("Interrupted connecting to etcd at " + uri, e));
+    } catch (ExecutionException e) {
+      Throwable cause = e.getCause() != null ? e.getCause() : e;
+      throw new RuntimeIOException(
+          new IOException(
+              "Failed to connect to etcd at " + uri + ": " + cause.getMessage(), cause));
+    }
     this.io = io;
   }
 
@@ -145,19 +172,30 @@ public class EtcdCatalog extends BaseMetastoreCatalog implements SupportsNamespa
 
   private static <T> T unwrapCommit(java.util.concurrent.CompletableFuture<T> x) {
     try {
-      return x.get();
-    } catch (InterruptedException | ExecutionException e) {
-      // TODO: Thread.currentThread().interrupt();?
+      return x.get(DEFAULT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    } catch (TimeoutException e) {
+      throw new CommitStateUnknownException(
+          new IOException("etcd commit timed out after " + DEFAULT_TIMEOUT_SECONDS + "s", e));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new CommitStateUnknownException(e);
+    } catch (ExecutionException e) {
       throw new CommitStateUnknownException(e);
     }
   }
 
   private static <T> T unwrap(java.util.concurrent.CompletableFuture<T> x) {
     try {
-      return x.get();
-    } catch (InterruptedException | ExecutionException e) {
-      // TODO: Thread.currentThread().interrupt();?
+      return x.get(DEFAULT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    } catch (TimeoutException e) {
+      throw new RuntimeIOException(
+          new IOException("etcd request timed out after " + DEFAULT_TIMEOUT_SECONDS + "s", e));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       throw new RuntimeIOException(new IOException(e));
+    } catch (ExecutionException e) {
+      Throwable cause = e.getCause() != null ? e.getCause() : e;
+      throw new RuntimeIOException(new IOException(cause.getMessage(), cause));
     }
   }
 

--- a/ice-rest-catalog/src/main/java/com/altinity/ice/rest/catalog/internal/etcd/EtcdCatalog.java
+++ b/ice-rest-catalog/src/main/java/com/altinity/ice/rest/catalog/internal/etcd/EtcdCatalog.java
@@ -98,8 +98,7 @@ public class EtcdCatalog extends BaseMetastoreCatalog implements SupportsNamespa
               e));
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      throw new RuntimeIOException(
-          new IOException("Interrupted connecting to etcd at " + uri, e));
+      throw new RuntimeIOException(new IOException("Interrupted connecting to etcd at " + uri, e));
     } catch (ExecutionException e) {
       Throwable cause = e.getCause() != null ? e.getCause() : e;
       throw new RuntimeIOException(


### PR DESCRIPTION
closes: #166 


`
 Catalog backend: SQLite (jdbc:sqlite:file:data/ice-rest-catalog/db.sqlite?journal_mode=WAL&synchronous=OFF&journal_size_limit=500); not recommended for production use
`

```
2026-05-12 12:49:31 [main/97818] ERROR c.a.ice.rest.catalog.Main > Fatal
org.apache.iceberg.exceptions.RuntimeIOException: java.io.IOException: Failed to connect to etcd at http://localhost:2379: timed out after 30s
        at com.altinity.ice.rest.catalog.internal.etcd.EtcdCatalog.<init>(EtcdCatalog.java:91)
        at com.altinity.ice.rest.catalog.Main.newEctdCatalog(Main.java:618)
        at com.altinity.ice.rest.catalog.Main.loadCatalog(Main.java:536)
        at com.altinity.ice.rest.catalog.Main.call(Main.java:446)
        at com.altinity.ice.rest.catalog.Main.call(Main.java:76)
        at com.altinity.ice.rest.catalog.Main.main(Main.java:629) [8 skipped]
Caused by: java.io.IOException: Failed to connect to etcd at http://localhost:2379: timed out after 30s
        ... 14 common frames omitted
Caused by: java.util.concurrent.TimeoutException: null
        at com.altinity.ice.rest.catalog.internal.etcd.EtcdCatalog.<init>(EtcdCatalog.java:88) [2 skipped]
        at com.altinity.ice.rest.catalog.Main.newEctdCatalog(Main.java:618)
        at com.altinity.ice.rest.catalog.Main.loadCatalog(Main.java:536)
        ... 13 common frames omitted
```