### PR TITLE
feat: Add logic to include client-id to group requests from same Iceberg client

### DIFF
--- a/ice-rest-catalog/README.md
+++ b/ice-rest-catalog/README.md
@@ -24,6 +24,23 @@ commitLock:
 
 If `enabled` is true but the catalog backend is not etcd, the lock is ignored (warning in logs). When lock acquisition exceeds `acquireTimeoutMs`, the server responds with HTTP **503** so clients can retry.
 
+## Debugging REST API traffic
+
+Set `ICE_REST_CATALOG_LOG_LEVEL=DEBUG` to log the full JSON request and response bodies for every REST call. This is useful for inspecting exactly what an Iceberg client sends and what the server returns.
+
+**Local:**
+```bash
+ICE_REST_CATALOG_LOG_LEVEL=DEBUG java -jar ice-rest-catalog/target/ice-rest-catalog-jar
+```
+
+**Docker / docker-compose:**
+```yaml
+environment:
+  ICE_REST_CATALOG_LOG_LEVEL: DEBUG
+```
+
+The default level is `INFO`, which logs one line per request (`@uid METHOD path`) without bodies.
+
 ## Documentation
 
 - [Architecture](../docs/architecture.md) -- components, design principles, HA, backup/recovery

--- a/ice-rest-catalog/pom.xml
+++ b/ice-rest-catalog/pom.xml
@@ -598,6 +598,7 @@
             <exclude>**/DockerScenarioBasedIT.java</exclude>
             <exclude>**/DockerLocalFileIOClickHouseIT.java</exclude>
             <exclude>**/DockerLocalFileIOClickHouseAllTypesIT.java</exclude>
+            <exclude>**/DockerSparkClientIdIT.java</exclude>
           </excludes>
         </configuration>
       </plugin>

--- a/ice-rest-catalog/src/main/java/com/altinity/ice/rest/catalog/Main.java
+++ b/ice-rest-catalog/src/main/java/com/altinity/ice/rest/catalog/Main.java
@@ -38,7 +38,9 @@ import com.altinity.ice.rest.catalog.internal.rest.RESTCatalogMiddlewareConfig;
 import com.altinity.ice.rest.catalog.internal.rest.RESTCatalogMiddlewareCredentials;
 import com.altinity.ice.rest.catalog.internal.rest.RESTCatalogMiddlewareTableConfig;
 import com.altinity.ice.rest.catalog.internal.rest.RESTCatalogMiddlewareTableCredentials;
+import com.altinity.ice.rest.catalog.internal.rest.RESTCatalogMiddlewareTracing;
 import com.altinity.ice.rest.catalog.internal.rest.RESTCatalogServlet;
+import com.altinity.ice.rest.catalog.internal.rest.RequestTracing;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.net.HostAndPort;
 import io.prometheus.metrics.instrumentation.jvm.JvmMetrics;
@@ -324,6 +326,14 @@ public final class Main implements Callable<Integer> {
       }
     }
 
+    var tracingConfig = config.tracing();
+    if (tracingConfig.enabledOrDefault() && tracingConfig.advertiseClientIdOrDefault()) {
+      restCatalogAdapter =
+          new RESTCatalogMiddlewareTracing(
+              restCatalogAdapter, tracingConfig.clientIdHeaderOrDefault());
+    }
+    RequestTracing tracing = new RequestTracing(tracingConfig);
+
     logger.info(
         "Commit retry config: numRetries={} minWaitMs={} maxWaitMs={} totalTimeoutMs={}",
         config.commitRetry().numRetries(),
@@ -336,7 +346,7 @@ public final class Main implements Callable<Integer> {
         config.commitLock().leaseTtlSeconds(),
         config.commitLock().acquireTimeoutMs());
 
-    var h = new ServletHolder(new RESTCatalogServlet(restCatalogAdapter));
+    var h = new ServletHolder(new RESTCatalogServlet(restCatalogAdapter, tracing));
     mux.addServlet(h, "/*");
 
     if (registerAdminServlet) {

--- a/ice-rest-catalog/src/main/java/com/altinity/ice/rest/catalog/internal/config/Config.java
+++ b/ice-rest-catalog/src/main/java/com/altinity/ice/rest/catalog/internal/config/Config.java
@@ -68,7 +68,10 @@ public record Config(
     @JsonPropertyDescription(
             "(experimental) Iceberg properties (see https://iceberg.apache.org/javadoc/1.8.1/"
                 + "; e.g. https://iceberg.apache.org/javadoc/1.8.1/org/apache/iceberg/aws/s3/S3FileIOProperties.html)")
-        Map<String, String> icebergProperties) {
+        Map<String, String> icebergProperties,
+    @JsonPropertyDescription(
+            "OpenTelemetry tracing and request/client correlation config (disabled by default)")
+        TracingConfig tracing) {
 
   private static final String DEFAULT_ADDR = "0.0.0.0:5000";
   private static final String DEFAULT_DEBUG_ADDR = "0.0.0.0:5001";
@@ -90,7 +93,8 @@ public record Config(
       CommitRetryConfig commitRetry,
       CommitLockConfig commitLock,
       Map<String, String> loadTableProperties,
-      @JsonProperty("iceberg") Map<String, String> icebergProperties) {
+      @JsonProperty("iceberg") Map<String, String> icebergProperties,
+      TracingConfig tracing) {
     this.addr = Strings.orDefault(addr, DEFAULT_ADDR);
     this.debugAddr = Strings.orDefault(debugAddr, DEFAULT_DEBUG_ADDR);
     this.adminAddr = Strings.orDefault(adminAddr, System.getenv("ICE_REST_CATALOG_ADMIN_ADDR"));
@@ -110,6 +114,7 @@ public record Config(
     this.commitLock = Objects.requireNonNullElse(commitLock, CommitLockConfig.defaults());
     this.loadTableProperties = Objects.requireNonNullElse(loadTableProperties, Map.of());
     this.icebergProperties = Objects.requireNonNullElse(icebergProperties, Map.of());
+    this.tracing = Objects.requireNonNullElse(tracing, TracingConfig.defaults());
   }
 
   public record S3(

--- a/ice-rest-catalog/src/main/java/com/altinity/ice/rest/catalog/internal/config/TracingConfig.java
+++ b/ice-rest-catalog/src/main/java/com/altinity/ice/rest/catalog/internal/config/TracingConfig.java
@@ -15,10 +15,11 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 /**
  * Per-request / per-client correlation configuration.
  *
- * <p>Adds a stable {@code clientId} (grouping all calls from one Iceberg client) and a per-request
- * {@code requestId} to logs (via MDC) and response headers, so a whole client session can be
- * grouped from the logs alone. All settings are optional; the feature is on by default and has no
- * external dependencies.
+ * <p>Adds a stable {@code clientId} (a deterministic per-identity fingerprint grouping all calls
+ * from the same uid + remote address + user-agent, including across separate client runs) and a
+ * per-request {@code requestId} to logs (via MDC) and response headers, so a whole client's
+ * activity can be grouped from the logs alone. All settings are optional; the feature is on by
+ * default and has no external dependencies.
  */
 public record TracingConfig(
     @JsonPropertyDescription(
@@ -30,7 +31,7 @@ public record TracingConfig(
     @JsonPropertyDescription("Header carrying the per-request id (X-Request-Id)")
         String requestIdHeader,
     @JsonPropertyDescription(
-            "Advertise a generated client id via the /v1/config response so Iceberg Java/PyIceberg clients echo it on every request (true by default)")
+            "Advertise the resolved (deterministic fingerprint) client id via the /v1/config response so Iceberg Java/PyIceberg clients echo the same id on every request, keeping it stable across runs (true by default)")
         Boolean advertiseClientId) {
 
   public static final String DEFAULT_CLIENT_ID_HEADER = "X-Ice-Client-Id";

--- a/ice-rest-catalog/src/main/java/com/altinity/ice/rest/catalog/internal/config/TracingConfig.java
+++ b/ice-rest-catalog/src/main/java/com/altinity/ice/rest/catalog/internal/config/TracingConfig.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025 Altinity Inc and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.altinity.ice.rest.catalog.internal.config;
+
+import com.altinity.ice.internal.strings.Strings;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+/**
+ * Per-request / per-client correlation configuration.
+ *
+ * <p>Adds a stable {@code clientId} (grouping all calls from one Iceberg client) and a per-request
+ * {@code requestId} to logs (via MDC) and response headers, so a whole client session can be
+ * grouped from the logs alone. All settings are optional; the feature is on by default and has no
+ * external dependencies.
+ */
+public record TracingConfig(
+    @JsonPropertyDescription(
+            "Enable request/client correlation ids in logs and response headers (true by default)")
+        Boolean enabled,
+    @JsonPropertyDescription(
+            "Header carrying the per-client id echoed by Iceberg clients (X-Ice-Client-Id)")
+        String clientIdHeader,
+    @JsonPropertyDescription("Header carrying the per-request id (X-Request-Id)")
+        String requestIdHeader,
+    @JsonPropertyDescription(
+            "Advertise a generated client id via the /v1/config response so Iceberg Java/PyIceberg clients echo it on every request (true by default)")
+        Boolean advertiseClientId) {
+
+  public static final String DEFAULT_CLIENT_ID_HEADER = "X-Ice-Client-Id";
+  public static final String DEFAULT_REQUEST_ID_HEADER = "X-Request-Id";
+
+  public static TracingConfig defaults() {
+    return new TracingConfig(null, null, null, null);
+  }
+
+  public boolean enabledOrDefault() {
+    return enabled == null || enabled;
+  }
+
+  public String clientIdHeaderOrDefault() {
+    return !Strings.isNullOrEmpty(clientIdHeader) ? clientIdHeader : DEFAULT_CLIENT_ID_HEADER;
+  }
+
+  public String requestIdHeaderOrDefault() {
+    return !Strings.isNullOrEmpty(requestIdHeader) ? requestIdHeader : DEFAULT_REQUEST_ID_HEADER;
+  }
+
+  public boolean advertiseClientIdOrDefault() {
+    return advertiseClientId == null || advertiseClientId;
+  }
+}

--- a/ice-rest-catalog/src/main/java/com/altinity/ice/rest/catalog/internal/rest/RESTCatalogMiddlewareTracing.java
+++ b/ice-rest-catalog/src/main/java/com/altinity/ice/rest/catalog/internal/rest/RESTCatalogMiddlewareTracing.java
@@ -13,14 +13,19 @@ import com.altinity.ice.rest.catalog.internal.auth.Session;
 import java.util.Map;
 import org.apache.iceberg.rest.RESTResponse;
 import org.apache.iceberg.rest.responses.ConfigResponse;
+import org.slf4j.MDC;
 
 /**
- * Advertises a per-client id to Iceberg clients via the {@code /v1/config} handshake.
+ * Advertises the client id to Iceberg clients via the {@code /v1/config} handshake.
  *
- * <p>The id is returned as a {@code header.<clientIdHeader>} override. Iceberg Java and PyIceberg
- * merge config overrides and re-send matching {@code header.*} properties on every subsequent
- * request, so all calls from that client instance share one {@code clientId}. Clients that ignore
- * config overrides (e.g. ClickHouse) simply fall back to the server-side fingerprint.
+ * <p>The advertised value is the id already resolved for the config request (read from the {@link
+ * MDC}) - a deterministic per-identity fingerprint ({@code fp-...}) derived from uid + remote
+ * address + user-agent. It is returned as a {@code header.<clientIdHeader>} override. Iceberg Java
+ * and PyIceberg merge config overrides and re-send matching {@code header.*} properties on every
+ * subsequent request, so all calls from that identity share one {@code clientId} - and because the
+ * value is deterministic (not a random per-instance id), it stays stable across separate
+ * short-lived client runs. Clients that ignore config overrides (e.g. ClickHouse) fall back to the
+ * same server-side fingerprint anyway.
  */
 public class RESTCatalogMiddlewareTracing extends RESTCatalogMiddleware {
 
@@ -42,9 +47,12 @@ public class RESTCatalogMiddlewareTracing extends RESTCatalogMiddleware {
       Class<T> responseType) {
     T restResponse = this.next.handle(session, route, vars, requestBody, responseType);
     if (restResponse instanceof ConfigResponse configResponse) {
-      configResponse
-          .overrides()
-          .putIfAbsent(HEADER_PREFIX + clientIdHeader, RequestTracing.newClientId());
+      // Advertise the id already resolved for this config request (the stable fingerprint), so
+      // echoing clients keep using the same deterministic id across runs.
+      String clientId = MDC.get(RequestTracing.MDC_CLIENT_ID);
+      if (clientId != null && !clientId.isEmpty()) {
+        configResponse.overrides().putIfAbsent(HEADER_PREFIX + clientIdHeader, clientId);
+      }
     }
     return restResponse;
   }

--- a/ice-rest-catalog/src/main/java/com/altinity/ice/rest/catalog/internal/rest/RESTCatalogMiddlewareTracing.java
+++ b/ice-rest-catalog/src/main/java/com/altinity/ice/rest/catalog/internal/rest/RESTCatalogMiddlewareTracing.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2025 Altinity Inc and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.altinity.ice.rest.catalog.internal.rest;
+
+import com.altinity.ice.rest.catalog.internal.auth.Session;
+import java.util.Map;
+import org.apache.iceberg.rest.RESTResponse;
+import org.apache.iceberg.rest.responses.ConfigResponse;
+
+/**
+ * Advertises a per-client id to Iceberg clients via the {@code /v1/config} handshake.
+ *
+ * <p>The id is returned as a {@code header.<clientIdHeader>} override. Iceberg Java and PyIceberg
+ * merge config overrides and re-send matching {@code header.*} properties on every subsequent
+ * request, so all calls from that client instance share one {@code clientId}. Clients that ignore
+ * config overrides (e.g. ClickHouse) simply fall back to the server-side fingerprint.
+ */
+public class RESTCatalogMiddlewareTracing extends RESTCatalogMiddleware {
+
+  private static final String HEADER_PREFIX = "header.";
+
+  private final String clientIdHeader;
+
+  public RESTCatalogMiddlewareTracing(RESTCatalogHandler next, String clientIdHeader) {
+    super(next);
+    this.clientIdHeader = clientIdHeader;
+  }
+
+  @Override
+  public <T extends RESTResponse> T handle(
+      Session session,
+      Route route,
+      Map<String, String> vars,
+      Object requestBody,
+      Class<T> responseType) {
+    T restResponse = this.next.handle(session, route, vars, requestBody, responseType);
+    if (restResponse instanceof ConfigResponse configResponse) {
+      configResponse
+          .overrides()
+          .putIfAbsent(HEADER_PREFIX + clientIdHeader, RequestTracing.newClientId());
+    }
+    return restResponse;
+  }
+}

--- a/ice-rest-catalog/src/main/java/com/altinity/ice/rest/catalog/internal/rest/RESTCatalogServlet.java
+++ b/ice-rest-catalog/src/main/java/com/altinity/ice/rest/catalog/internal/rest/RESTCatalogServlet.java
@@ -76,10 +76,12 @@ public class RESTCatalogServlet extends HttpServlet {
 
   private final RESTCatalogHandler restCatalogAdapter;
   private final HttpMetrics httpMetrics;
+  private final RequestTracing tracing;
 
-  public RESTCatalogServlet(RESTCatalogHandler restCatalogAdapter) {
+  public RESTCatalogServlet(RESTCatalogHandler restCatalogAdapter, RequestTracing tracing) {
     this.restCatalogAdapter = restCatalogAdapter;
     this.httpMetrics = HttpMetrics.getInstance();
+    this.tracing = tracing;
   }
 
   protected void handle(HttpServletRequest request, HttpServletResponse response)
@@ -87,6 +89,24 @@ public class RESTCatalogServlet extends HttpServlet {
     HTTPRequest.HTTPMethod method = HTTPRequest.HTTPMethod.valueOf(request.getMethod());
     String path = request.getRequestURI().substring(1);
 
+    Session session = Session.from(request);
+    String clientId = tracing.resolveClientId(request, session);
+    String requestId = tracing.resolveRequestId(request);
+    tracing.begin(response, clientId, requestId);
+    try {
+      handleTraced(method, path, session, request, response);
+    } finally {
+      tracing.end();
+    }
+  }
+
+  private void handleTraced(
+      HTTPRequest.HTTPMethod method,
+      String path,
+      Session session,
+      HttpServletRequest request,
+      HttpServletResponse response)
+      throws IOException {
     Pair<Route, Map<String, String>> routeContext = Route.from(method, path);
     if (routeContext == null) {
       // Track unknown route requests
@@ -110,7 +130,6 @@ public class RESTCatalogServlet extends HttpServlet {
 
     // Track request with metrics
     try (var timer = httpMetrics.startRequest(method.name(), route.name())) {
-      Session session = Session.from(request);
       String userToLog = "";
       if (session != null) {
         userToLog = "@" + session.uid() + " ";

--- a/ice-rest-catalog/src/main/java/com/altinity/ice/rest/catalog/internal/rest/RESTCatalogServlet.java
+++ b/ice-rest-catalog/src/main/java/com/altinity/ice/rest/catalog/internal/rest/RESTCatalogServlet.java
@@ -25,6 +25,7 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.hc.core5.http.ContentType;
@@ -141,10 +142,13 @@ public class RESTCatalogServlet extends HttpServlet {
       // FIXME: this should be in RESTCatalogAdapter, not here
       Object requestBody = null;
       if (route.requestClass() != null) {
-        requestBody =
-            RESTObjectMapper.mapper().readValue(request.getReader(), route.requestClass());
+        String rawBody = CharStreams.toString(request.getReader());
+        logger.debug("{}{} {} request body: {}", userToLog, method, path, rawBody);
+        requestBody = RESTObjectMapper.mapper().readValue(rawBody, route.requestClass());
       } else if (route == Route.TOKENS) {
-        requestBody = RESTUtil.decodeFormData(CharStreams.toString(request.getReader()));
+        String rawBody = CharStreams.toString(request.getReader());
+        logger.debug("{}{} {} request body: <redacted>", userToLog, method, path);
+        requestBody = RESTUtil.decodeFormData(rawBody);
       }
 
       Map<String, String> queryParams =
@@ -176,6 +180,12 @@ public class RESTCatalogServlet extends HttpServlet {
         response.setStatus(error.code());
         response.setHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType());
         byte[] errorBytes = RESTObjectMapper.mapper().writeValueAsBytes(error);
+        logger.debug(
+            "{}{} {} error response body: {}",
+            userToLog,
+            method,
+            path,
+            new String(errorBytes, StandardCharsets.UTF_8));
         timer.setResponseSize(errorBytes.length);
         response.getOutputStream().write(errorBytes);
         return;
@@ -186,6 +196,12 @@ public class RESTCatalogServlet extends HttpServlet {
       response.setHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType());
       if (responseBody != null) {
         byte[] responseBytes = RESTObjectMapper.mapper().writeValueAsBytes(responseBody);
+        logger.debug(
+            "{}{} {} response body: {}",
+            userToLog,
+            method,
+            path,
+            new String(responseBytes, StandardCharsets.UTF_8));
         timer.setResponseSize(responseBytes.length);
         response.getOutputStream().write(responseBytes);
       }

--- a/ice-rest-catalog/src/main/java/com/altinity/ice/rest/catalog/internal/rest/RequestTracing.java
+++ b/ice-rest-catalog/src/main/java/com/altinity/ice/rest/catalog/internal/rest/RequestTracing.java
@@ -22,18 +22,24 @@ import org.slf4j.MDC;
 /**
  * Resolves and propagates per-client / per-request correlation identifiers.
  *
- * <p>{@code clientId} groups every call from a single Iceberg client instance; {@code requestId} is
- * unique per HTTP request. Both are placed in the SLF4J {@link MDC} (rendered by the logback
- * pattern) and echoed back as response headers.
+ * <p>{@code clientId} groups every call from a single identity; {@code requestId} is unique per
+ * HTTP request. Both are placed in the SLF4J {@link MDC} (rendered by the logback pattern) and
+ * echoed back as response headers.
  *
- * <p>Client id resolution degrades gracefully:
+ * <p>Client id resolution:
  *
  * <ul>
- *   <li>If the request carries the client-id header (Iceberg Java / PyIceberg echo it once the
- *       server advertises it via the {@code /v1/config} response), that value is used.
+ *   <li>If the request carries the client-id header, that value is used. Iceberg Java / PyIceberg
+ *       echo it once the server advertises it via the {@code /v1/config} response, so all calls
+ *       from that client re-send the same value.
  *   <li>Otherwise a stable fingerprint derived from the auth token, remote address and User-Agent
- *       is used. This covers clients (e.g. ClickHouse) that do not echo config headers.
+ *       is used. This covers the {@code /v1/config} request itself (before the header is echoed)
+ *       and clients (e.g. ClickHouse) that do not echo config headers.
  * </ul>
+ *
+ * <p>The advertised id is this same fingerprint (see {@code RESTCatalogMiddlewareTracing}), so it
+ * is deterministic per identity and stable across separate client runs, giving identity-level
+ * grouping.
  */
 public final class RequestTracing {
 
@@ -57,11 +63,6 @@ public final class RequestTracing {
 
   public String clientIdHeader() {
     return clientIdHeader;
-  }
-
-  /** A freshly generated client id, suitable for advertising via the config response. */
-  public static String newClientId() {
-    return UUID.randomUUID().toString();
   }
 
   /** Client id from the request header, falling back to a stable fingerprint. */

--- a/ice-rest-catalog/src/main/java/com/altinity/ice/rest/catalog/internal/rest/RequestTracing.java
+++ b/ice-rest-catalog/src/main/java/com/altinity/ice/rest/catalog/internal/rest/RequestTracing.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2025 Altinity Inc and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.altinity.ice.rest.catalog.internal.rest;
+
+import com.altinity.ice.internal.strings.Strings;
+import com.altinity.ice.rest.catalog.internal.auth.Session;
+import com.altinity.ice.rest.catalog.internal.config.TracingConfig;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import java.util.zip.CRC32;
+import org.slf4j.MDC;
+
+/**
+ * Resolves and propagates per-client / per-request correlation identifiers.
+ *
+ * <p>{@code clientId} groups every call from a single Iceberg client instance; {@code requestId} is
+ * unique per HTTP request. Both are placed in the SLF4J {@link MDC} (rendered by the logback
+ * pattern) and echoed back as response headers.
+ *
+ * <p>Client id resolution degrades gracefully:
+ *
+ * <ul>
+ *   <li>If the request carries the client-id header (Iceberg Java / PyIceberg echo it once the
+ *       server advertises it via the {@code /v1/config} response), that value is used.
+ *   <li>Otherwise a stable fingerprint derived from the auth token, remote address and User-Agent
+ *       is used. This covers clients (e.g. ClickHouse) that do not echo config headers.
+ * </ul>
+ */
+public final class RequestTracing {
+
+  public static final String MDC_CLIENT_ID = "clientId";
+  public static final String MDC_REQUEST_ID = "requestId";
+
+  private final boolean enabled;
+  private final String clientIdHeader;
+  private final String requestIdHeader;
+
+  public RequestTracing(TracingConfig config) {
+    TracingConfig c = config != null ? config : TracingConfig.defaults();
+    this.enabled = c.enabledOrDefault();
+    this.clientIdHeader = c.clientIdHeaderOrDefault();
+    this.requestIdHeader = c.requestIdHeaderOrDefault();
+  }
+
+  public boolean enabled() {
+    return enabled;
+  }
+
+  public String clientIdHeader() {
+    return clientIdHeader;
+  }
+
+  /** A freshly generated client id, suitable for advertising via the config response. */
+  public static String newClientId() {
+    return UUID.randomUUID().toString();
+  }
+
+  /** Client id from the request header, falling back to a stable fingerprint. */
+  public String resolveClientId(HttpServletRequest request, Session session) {
+    String fromHeader = request.getHeader(clientIdHeader);
+    if (!Strings.isNullOrEmpty(fromHeader)) {
+      return fromHeader;
+    }
+    return fingerprint(request, session);
+  }
+
+  /** Request id from the request header, falling back to a freshly generated UUID. */
+  public String resolveRequestId(HttpServletRequest request) {
+    String fromHeader = request.getHeader(requestIdHeader);
+    if (!Strings.isNullOrEmpty(fromHeader)) {
+      return fromHeader;
+    }
+    return UUID.randomUUID().toString();
+  }
+
+  public void begin(HttpServletResponse response, String clientId, String requestId) {
+    MDC.put(MDC_CLIENT_ID, clientId);
+    MDC.put(MDC_REQUEST_ID, requestId);
+    if (response != null && !response.isCommitted()) {
+      response.setHeader(clientIdHeader, clientId);
+      response.setHeader(requestIdHeader, requestId);
+    }
+  }
+
+  public void end() {
+    MDC.remove(MDC_CLIENT_ID);
+    MDC.remove(MDC_REQUEST_ID);
+  }
+
+  private static String fingerprint(HttpServletRequest request, Session session) {
+    String uid = session != null ? session.uid() : "anonymous";
+    String remote = request.getRemoteAddr();
+    String userAgent = request.getHeader("User-Agent");
+    String raw =
+        (uid != null ? uid : "")
+            + "|"
+            + (remote != null ? remote : "")
+            + "|"
+            + (userAgent != null ? userAgent : "");
+    CRC32 crc = new CRC32();
+    crc.update(raw.getBytes(StandardCharsets.UTF_8));
+    return "fp-" + Long.toHexString(crc.getValue());
+  }
+}

--- a/ice-rest-catalog/src/test/java/com/altinity/ice/rest/catalog/DockerSparkClientIdIT.java
+++ b/ice-rest-catalog/src/test/java/com/altinity/ice/rest/catalog/DockerSparkClientIdIT.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) 2025 Altinity Inc and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.altinity.ice.rest.catalog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Container;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.MountableFile;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+
+/**
+ * Docker-based integration test that verifies request/client-id grouping.
+ *
+ * <p>Runs Apache Spark (spark-iceberg image) as an Iceberg REST client against the ice-rest-catalog
+ * container and asserts that every catalog call made by a single Spark session shares one
+ * server-assigned client id (the {@code X-Ice-Client-Id} UUID advertised via {@code /v1/config} and
+ * echoed back by the Iceberg Java client). Grouping is checked from the catalog container logs,
+ * where the logback pattern renders {@code %X{clientId}} on each request line.
+ *
+ * <p>Excluded from the default Failsafe run (see {@code ice-rest-catalog/pom.xml}); run explicitly
+ * with {@code ./mvnw -pl ice-rest-catalog verify -Dit.test=DockerSparkClientIdIT}. Requires Docker
+ * and a locally-built, tracing-enabled catalog image. This test depends on the request/client-id
+ * tracing feature, which is not present in published images, so the image must be built from
+ * current source first via {@code .bin/local-docker-build-ice-rest-catalog} (or {@code docker build
+ * --build-arg BASE_IMAGE_TAG=debug -t altinity/ice-rest-catalog:debug-with-ice-local -f
+ * ice-rest-catalog/Dockerfile.debug-with-ice .}). Override the image with {@code
+ * -Ddocker.image=...}.
+ */
+public class DockerSparkClientIdIT {
+
+  private static final Logger logger = LoggerFactory.getLogger(DockerSparkClientIdIT.class);
+
+  private static final String SPARK_IMAGE = "tabulario/spark-iceberg:3.5.5_1.8.1";
+
+  // Strips ANSI escape codes (present only if the catalog runs with a color-capable terminal).
+  private static final Pattern ANSI = Pattern.compile("\u001B\\[[;\\d]*m");
+
+  // Matches request log lines emitted by RESTCatalogServlet:
+  // "... RESTCatalogServlet > <clientId> <requestId> @token:anonymous <METHOD> v1/<path>".
+  // Anchoring on the logger name avoids false matches when MDC ids are absent.
+  private static final Pattern REQUEST_LINE =
+      Pattern.compile(
+          "RESTCatalogServlet > (\\S+) (\\S+) @token:anonymous (GET|POST|HEAD|DELETE) (v1/\\S+)");
+
+  private static final Pattern UUID_PATTERN =
+      Pattern.compile(
+          "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}");
+
+  private Network network;
+  private GenericContainer<?> minio;
+  private GenericContainer<?> catalog;
+  private GenericContainer<?> spark;
+
+  @BeforeClass
+  @SuppressWarnings("resource")
+  public void setUp() throws Exception {
+    String dockerImage =
+        System.getProperty("docker.image", "altinity/ice-rest-catalog:debug-with-ice-local");
+    logger.info("Using catalog Docker image: {}", dockerImage);
+
+    network = Network.newNetwork();
+
+    // Start MinIO
+    minio =
+        new GenericContainer<>("minio/minio:latest")
+            .withNetwork(network)
+            .withNetworkAliases("minio")
+            .withExposedPorts(9000)
+            .withEnv("MINIO_ACCESS_KEY", "minioadmin")
+            .withEnv("MINIO_SECRET_KEY", "minioadmin")
+            .withCommand("server", "/data")
+            .waitingFor(Wait.forHttp("/minio/health/live").forPort(9000));
+    minio.start();
+
+    // Create test bucket via MinIO's host-mapped port
+    String minioHostEndpoint = "http://" + minio.getHost() + ":" + minio.getMappedPort(9000);
+    try (var s3Client =
+        S3Client.builder()
+            .endpointOverride(URI.create(minioHostEndpoint))
+            .region(Region.US_EAST_1)
+            .credentialsProvider(
+                StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create("minioadmin", "minioadmin")))
+            .forcePathStyle(true)
+            .build()) {
+      s3Client.createBucket(CreateBucketRequest.builder().bucket("test-bucket").build());
+      logger.info("Created test-bucket in MinIO");
+    }
+
+    // Catalog config (SQLite metastore, MinIO warehouse, anonymous read-write, tracing defaults on)
+    URL configResource = getClass().getClassLoader().getResource("docker-catalog-config.yaml");
+    if (configResource == null) {
+      throw new IllegalStateException("docker-catalog-config.yaml not found on classpath");
+    }
+    String catalogConfig = Files.readString(Paths.get(configResource.toURI()));
+
+    // Start the ice-rest-catalog container
+    catalog =
+        new GenericContainer<>(dockerImage)
+            .withNetwork(network)
+            .withNetworkAliases("catalog")
+            .withExposedPorts(5000)
+            .withEnv("ICE_REST_CATALOG_CONFIG", "")
+            .withEnv("ICE_REST_CATALOG_CONFIG_YAML", catalogConfig)
+            .waitingFor(Wait.forHttp("/v1/config").forPort(5000).forStatusCode(200));
+
+    try {
+      catalog.start();
+    } catch (Exception e) {
+      if (catalog != null) {
+        logger.error("Catalog container logs: {}", catalog.getLogs());
+      }
+      throw e;
+    }
+
+    // Spark client, configured to talk to the co-located catalog + MinIO over the Docker network.
+    Path sparkDefaults = Files.createTempFile("spark-defaults-", ".conf");
+    Files.writeString(sparkDefaults, sparkDefaultsConf(), StandardCharsets.UTF_8);
+
+    spark =
+        new GenericContainer<>(SPARK_IMAGE)
+            .withNetwork(network)
+            .withNetworkAliases("spark")
+            .withExposedPorts(8888)
+            .withCopyFileToContainer(
+                MountableFile.forHostPath(sparkDefaults), "/opt/spark/conf/spark-defaults.conf")
+            .waitingFor(Wait.forListeningPort().withStartupTimeout(Duration.ofMinutes(5)));
+
+    try {
+      spark.start();
+    } catch (Exception e) {
+      if (spark != null) {
+        logger.error("Spark container logs: {}", spark.getLogs());
+      }
+      throw e;
+    }
+
+    logger.info(
+        "Catalog started at {}:{}, Spark started ({})",
+        catalog.getHost(),
+        catalog.getMappedPort(5000),
+        spark.getContainerId());
+  }
+
+  @AfterClass
+  public void tearDown() {
+    if (spark != null) {
+      spark.close();
+    }
+    if (catalog != null) {
+      catalog.close();
+    }
+    if (minio != null) {
+      minio.close();
+    }
+    if (network != null) {
+      network.close();
+    }
+  }
+
+  @Test
+  public void sparkRequestsShareOneClientId() throws Exception {
+    // A single spark-sql invocation == one SparkSession == one Iceberg RESTCatalog client, which
+    // performs one /v1/config handshake followed by several catalog operations.
+    String sql =
+        "CREATE NAMESPACE IF NOT EXISTS spark_ns; "
+            + "CREATE TABLE spark_ns.t (id BIGINT) USING iceberg; "
+            + "INSERT INTO spark_ns.t VALUES (1),(2),(3); "
+            + "SELECT COUNT(*) FROM spark_ns.t;";
+
+    Container.ExecResult result =
+        spark.execInContainer("bash", "-c", "/opt/spark/bin/spark-sql -e \"" + sql + "\"");
+
+    if (result.getExitCode() != 0) {
+      logger.error("spark-sql stdout:\n{}", result.getStdout());
+      logger.error("spark-sql stderr:\n{}", result.getStderr());
+      logger.error("catalog logs:\n{}", catalog.getLogs());
+    }
+    assertThat(result.getExitCode())
+        .as("spark-sql should succeed; stderr: %s", result.getStderr())
+        .isEqualTo(0);
+
+    String logs = ANSI.matcher(catalog.getLogs()).replaceAll("");
+
+    Set<String> operationClientIds = new LinkedHashSet<>();
+    int operationRequests = 0;
+    String configClientId = null;
+    Matcher m = REQUEST_LINE.matcher(logs);
+    while (m.find()) {
+      String clientId = m.group(1);
+      String path = m.group(4);
+      if (path.startsWith("v1/config")) {
+        configClientId = clientId;
+      } else {
+        operationClientIds.add(clientId);
+        operationRequests++;
+      }
+    }
+
+    logger.info(
+        "Parsed {} operation requests; config clientId={}, operation clientIds={}",
+        operationRequests,
+        configClientId,
+        operationClientIds);
+
+    assertThat(operationRequests)
+        .as("expected multiple catalog operations from the Spark session")
+        .isGreaterThanOrEqualTo(2);
+
+    assertThat(operationClientIds)
+        .as("all operations from one Spark client must share a single client id")
+        .hasSize(1);
+
+    String sharedClientId = operationClientIds.iterator().next();
+    assertThat(sharedClientId)
+        .as("shared client id must be the server-advertised UUID echoed by Spark")
+        .matches(UUID_PATTERN);
+  }
+
+  private static String sparkDefaultsConf() {
+    return String.join(
+            "\n",
+            "spark.sql.extensions org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            "spark.sql.catalog.demo org.apache.iceberg.spark.SparkCatalog",
+            "spark.sql.catalog.demo.type rest",
+            "spark.sql.catalog.demo.uri http://catalog:5000",
+            "spark.sql.catalog.demo.io-impl org.apache.iceberg.aws.s3.S3FileIO",
+            "spark.sql.catalog.demo.warehouse s3://test-bucket/warehouse",
+            "spark.sql.catalog.demo.s3.endpoint http://minio:9000",
+            "spark.sql.catalog.demo.s3.path-style-access true",
+            "spark.sql.catalog.demo.s3.access-key minioadmin",
+            "spark.sql.catalog.demo.s3.secret-key minioadmin",
+            "spark.sql.catalog.demo.client.region us-east-1",
+            "spark.sql.catalog.demo.s3.ssl-enabled false",
+            "spark.sql.defaultCatalog demo",
+            "spark.sql.catalogImplementation in-memory")
+        + "\n";
+  }
+}

--- a/ice-rest-catalog/src/test/java/com/altinity/ice/rest/catalog/DockerSparkClientIdIT.java
+++ b/ice-rest-catalog/src/test/java/com/altinity/ice/rest/catalog/DockerSparkClientIdIT.java
@@ -42,10 +42,11 @@ import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
  * Docker-based integration test that verifies request/client-id grouping.
  *
  * <p>Runs Apache Spark (spark-iceberg image) as an Iceberg REST client against the ice-rest-catalog
- * container and asserts that every catalog call made by a single Spark session shares one
- * server-assigned client id (the {@code X-Ice-Client-Id} UUID advertised via {@code /v1/config} and
- * echoed back by the Iceberg Java client). Grouping is checked from the catalog container logs,
- * where the logback pattern renders {@code %X{clientId}} on each request line.
+ * container and asserts that every catalog call made by a single Spark session shares one client
+ * id. The id is the deterministic per-identity fingerprint ({@code fp-...}) advertised via {@code
+ * /v1/config} (and echoed back by the Iceberg Java client), so even the {@code /v1/config} request
+ * shares the same id as the operations. Grouping is checked from the catalog container logs, where
+ * the logback pattern renders {@code %X{clientId}} on each request line.
  *
  * <p>Excluded from the default Failsafe run (see {@code ice-rest-catalog/pom.xml}); run explicitly
  * with {@code ./mvnw -pl ice-rest-catalog verify -Dit.test=DockerSparkClientIdIT}. Requires Docker
@@ -72,9 +73,8 @@ public class DockerSparkClientIdIT {
       Pattern.compile(
           "RESTCatalogServlet > (\\S+) (\\S+) @token:anonymous (GET|POST|HEAD|DELETE) (v1/\\S+)");
 
-  private static final Pattern UUID_PATTERN =
-      Pattern.compile(
-          "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}");
+  // The deterministic per-identity fingerprint advertised by the catalog (fp-<crc32 hex>).
+  private static final Pattern FINGERPRINT_PATTERN = Pattern.compile("fp-[0-9a-fA-F]+");
 
   private Network network;
   private GenericContainer<?> minio;
@@ -243,8 +243,12 @@ public class DockerSparkClientIdIT {
 
     String sharedClientId = operationClientIds.iterator().next();
     assertThat(sharedClientId)
-        .as("shared client id must be the server-advertised UUID echoed by Spark")
-        .matches(UUID_PATTERN);
+        .as("shared client id must be the deterministic fingerprint advertised by the catalog")
+        .matches(FINGERPRINT_PATTERN);
+
+    assertThat(configClientId)
+        .as("the /v1/config request must share the same client id as the operations")
+        .isEqualTo(sharedClientId);
   }
 
   private static String sparkDefaultsConf() {

--- a/ice-rest-catalog/src/test/java/com/altinity/ice/rest/catalog/RESTCatalogTestBase.java
+++ b/ice-rest-catalog/src/test/java/com/altinity/ice/rest/catalog/RESTCatalogTestBase.java
@@ -106,7 +106,8 @@ public abstract class RESTCatalogTestBase {
             null, // commitRetry
             null, // commitLock
             null, // loadTableProperties
-            null // icebergProperties
+            null, // icebergProperties
+            null // tracing
             );
 
     // Create backend catalog from config

--- a/ice-rest-catalog/src/test/java/com/altinity/ice/rest/catalog/internal/rest/RESTCatalogAdapterCreateIT.java
+++ b/ice-rest-catalog/src/test/java/com/altinity/ice/rest/catalog/internal/rest/RESTCatalogAdapterCreateIT.java
@@ -82,6 +82,7 @@ public class RESTCatalogAdapterCreateIT {
             null,
             null,
             null,
+            null,
             null);
     catalog = CatalogUtil.buildIcebergCatalog("it", config.toIcebergConfig(), null);
     adapter = new RESTCatalogAdapter(catalog);

--- a/ice/src/main/resources/logback.xml
+++ b/ice/src/main/resources/logback.xml
@@ -33,7 +33,7 @@
     <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
       <layout class="com.altinity.ice.internal.logback.ColorAwarePatternLayout">
         <!-- FIXME: stacktrace filtering has perf implications -->
-        <pattern>%gray(%d{yyyy-MM-dd HH:mm:ss} [%.11thread/%processId]) %highlight(%-4level) %gray(%logger{27} >) %X{msgContext}%msg%n%replace(%ex{full,
+        <pattern>%gray(%d{yyyy-MM-dd HH:mm:ss} [%.11thread/%processId]) %highlight(%-4level) %gray(%logger{27} >) %gray(%X{clientId} %X{requestId}) %X{msgContext}%msg%n%replace(%ex{full,
           org.eclipse.jetty,
           jakarta.servlet,
           software.amazon.awssdk.core.internal,

--- a/ice/src/main/resources/logback.xml
+++ b/ice/src/main/resources/logback.xml
@@ -11,6 +11,9 @@
   <!--ice-rest-catalog-->
   <!--<logger name="org.apache.iceberg.CatalogUtil" level="WARN"/>-->
   <logger name="org.apache.iceberg.BaseMetastoreCatalog" level="WARN"/>
+  <!-- Set ICE_REST_CATALOG_LOG_LEVEL=DEBUG to log REST request/response bodies. -->
+  <logger name="com.altinity.ice.rest.catalog.internal.rest.RESTCatalogServlet"
+          level="${ICE_REST_CATALOG_LOG_LEVEL:-INFO}"/>
   <logger name="org.eclipse.jetty" level="WARN"/>
   <!-- hide "Unable to load metrics class: 'org.apache.iceberg.hadoop.HadoopMetricsContext', falling back to null metrics" -->
   <logger name="org.apache.iceberg.aws.s3.S3FileIO" level="ERROR"/>


### PR DESCRIPTION
closes: #10 
Logging REST catalog request/response so its easier to compare it with other catalog implementations.