### PR TITLE
fix: Fix unauthorized exception with ice due to missing auth header

### DIFF
--- a/ice/src/main/java/com/altinity/ice/cli/internal/iceberg/rest/RESTCatalogFactory.java
+++ b/ice/src/main/java/com/altinity/ice/cli/internal/iceberg/rest/RESTCatalogFactory.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.rest.HTTPClient;
 import org.apache.iceberg.rest.RESTCatalog;
+import org.apache.iceberg.rest.RESTUtil;
 
 public class RESTCatalogFactory {
 
@@ -63,6 +64,7 @@ public class RESTCatalogFactory {
         x ->
             HTTPClient.builder(x)
                 .uri(x.get(CatalogProperties.URI))
+                .withHeaders(RESTUtil.configHeaders(x))
                 .withTlsSocketStrategy(tlsSocketStrategy)
                 .build());
   }


### PR DESCRIPTION
Closes #195.

The Iceberg 1.8 -> 1.9 upgrade broke the bearer token auth for REST catalog requests. Iceberg 1.9 refactored the auth system which no longer passed header.* properties directly and instead passed it via the `HTTPClient.Builder`. We use a custom `HTTPClient` created by `RESTCatalogFactory` which wasn't updated to match this change. This caused requests to the catalog besides the initial `/config` request to be missing the "Authorization" header.

The fix was to pass the config headers to the `HTTPClient.Builder` in `RestCatalogFactory.create`, so that the "Authorization" header is properly included in all requests to the catalog.